### PR TITLE
HOTFIX: Fixed the endless loop, and corrected the return flag for reading.

### DIFF
--- a/code/headers/i2c_bus.hpp
+++ b/code/headers/i2c_bus.hpp
@@ -46,6 +46,13 @@ namespace r2d2::i2c {
          */
         uint8_t read_byte();
 
+        /**
+         * The amount of times the loop will check the necessary registers in a
+         * transaction before timeing out. Times out silently.
+         * @internal
+         */
+        constexpr static uint32_t timeout_counter = 10000;
+
     public:
         /**
          * Enum of the possible interface you can select when instantiating this


### PR DESCRIPTION
There were blocking-endless-loops in the library's read and write functions, they now silently return instead after checking the corresponding status register 10000 times.

I was also reading the wrong flag for transaction complete. 